### PR TITLE
bills: add updated_asc sort option

### DIFF
--- a/api/bills.py
+++ b/api/bills.py
@@ -25,6 +25,7 @@ class BillInclude(str, Enum):
 
 
 class BillSortOption(str, Enum):
+    updated_asc = "updated_asc"
     updated_desc = "updated_desc"
     first_action_asc = "first_action_asc"
     first_action_desc = "first_action_desc"
@@ -129,7 +130,9 @@ async def bills_search(
     """
     query = base_query(db)
 
-    if sort == BillSortOption.updated_desc:
+    if sort == BillSortOption.updated_asc:
+        query = query.order_by(models.Bill.updated_at)
+    elif sort == BillSortOption.updated_desc:
         query = query.order_by(desc(models.Bill.updated_at))
     elif sort == BillSortOption.first_action_asc:
         query = query.order_by(nullslast(models.Bill.first_action_date))

--- a/api/tests/test_bills.py
+++ b/api/tests/test_bills.py
@@ -242,6 +242,9 @@ def test_bills_sort_ordering_correct(client):
     bills = client.get("/bills/?jurisdiction=ne&sort=updated_desc").json()["results"]
     assert bills[0]["updated_at"] > bills[1]["updated_at"] > bills[2]["updated_at"]
 
+    bills = client.get("/bills/?jurisdiction=ne&sort=updated_asc").json()["results"]
+    assert bills[0]["updated_at"] < bills[1]["updated_at"] < bills[2]["updated_at"]
+
     bills = client.get("/bills/?jurisdiction=ne&sort=first_action_asc").json()[
         "results"
     ]


### PR DESCRIPTION
this is useful in conjunction with `updated_since` to be able to paginate from beginning to end and pick up where you left off