### PR TITLE
Fix nonetype error in jurisdiction_filter

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -4,6 +4,9 @@ from openstates.metadata import lookup
 
 
 def jurisdiction_filter(j: str, *, jid_field):
+    if not j:
+        # an empty object can't equal anything
+        return False
     # check either by Jurisdiction.name or a specified field's jurisdiction_id
     if len(j) == 2:
         try:


### PR DESCRIPTION
We can apparently reach `utils.jurisdiction_filter` with a `None` as our filter string:
```
TypeError: object of type 'NoneType' has no len()
(11 additional frame(s) were not displayed)
...
  File "starlette/routing.py", line 52, in app
    response = await func(request)
  File "fastapi/routing.py", line 226, in app
    raw_response = await run_endpoint_function(
  File "fastapi/routing.py", line 159, in run_endpoint_function
    return await dependant.call(**values)
  File "api/committees.py", line 61, in committee_list
    jurisdiction_filter(
  File "api/utils.py", line 8, in jurisdiction_filter
    if len(j) == 2:
```

Signed-off-by: John Seekins <john@civiceagle.com>