### PR TITLE
Fix deprecated Poetry installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM antonapetrov/uvicorn-gunicorn-fastapi:python3.9
 
 # install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false


### PR DESCRIPTION
Dockerfile for api-v3 was changed to use https://install.python-poetry.org after encountering an error due to `get-poetry.py` being deprecated. After applying this change, API v3 runs successfully and API functionality was confirmed to be working properly.

Here's the error that occurs after running `docker-compose up`:
```
failed to solve: executor failed running [/bin/sh -c curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python &&     cd /usr/local/bin &&     ln -s /opt/poetry/bin/poetry &&     poetry config virtualenvs.create false]: exit code: 1
```

Further details on the error indicate the installer that should be used:
```
This installer is deprecated, and scheduled for removal from the Poetry repository on or after January 1, 2023.
See https://github.com/python-poetry/poetry/issues/6377 for details.

You should migrate to https://install.python-poetry.org instead, which supports all versions of Poetry, and allows for `self update` of versions 1.1.7 or newer.
Instructions are available at https://python-poetry.org/docs/#installation.
```

Here's the issue describing the removal of `get-poetry.py`:
https://github.com/python-poetry/poetry/issues/6377