### PR TITLE
Fix possible stacktrace in people.geo and improve people.geo performance

### DIFF
--- a/api/people.py
+++ b/api/people.py
@@ -40,7 +40,7 @@ def people_query(db):
 
 
 router = APIRouter()
-session = reqeusts.Session()
+session = requests.Session()
 
 
 @router.get(

--- a/api/people.py
+++ b/api/people.py
@@ -141,9 +141,7 @@ async def people_geo(
     try:
         data = session.get(url).json()
     except Exception as e:
-        raise HTTPException(
-            500, f"Failed to retrieve data from Geo endpoint :: {e}"
-        )
+        raise HTTPException(500, f"Failed to retrieve data from Geo endpoint :: {e}")
     try:
         divisions = [d["id"] for d in data["divisions"]]
     except KeyError:

--- a/api/people.py
+++ b/api/people.py
@@ -140,6 +140,11 @@ async def people_geo(
     url = f"https://v3.openstates.org/divisions.geo?lat={lat}&lng={lng}"
     try:
         data = session.get(url).json()
+    except Exception as e:
+        raise HTTPException(
+            500, f"Failed to retrieve data from Geo endpoint :: {e}"
+        )
+    try:
         divisions = [d["id"] for d in data["divisions"]]
     except KeyError:
         raise HTTPException(

--- a/api/people.py
+++ b/api/people.py
@@ -40,6 +40,7 @@ def people_query(db):
 
 
 router = APIRouter()
+session = reqeusts.Session()
 
 
 @router.get(
@@ -137,8 +138,8 @@ async def people_geo(
     **Note:** Currently limited to state legislators and US Congress.  Governors & mayors are not included.
     """
     url = f"https://v3.openstates.org/divisions.geo?lat={lat}&lng={lng}"
-    data = requests.get(url).json()
     try:
+        data = session.get(url).json()
         divisions = [d["id"] for d in data["divisions"]]
     except KeyError:
         raise HTTPException(

--- a/api/tests/test_people.py
+++ b/api/tests/test_people.py
@@ -170,7 +170,7 @@ def test_people_include_office(client):
 
 
 def test_people_geo_basic(client):
-    with mock.patch("api.people.requests.get") as mock_get:
+    with mock.patch("api.people.session.get") as mock_get:
         mock_get.return_value.json.return_value = {
             "divisions": [
                 {
@@ -192,7 +192,7 @@ def test_people_geo_basic(client):
 
 def test_people_geo_bad_param(client):
     # missing parameter
-    with mock.patch("api.people.requests.get") as mock_get:
+    with mock.patch("api.people.session.get") as mock_get:
         response = client.get("/people.geo?lat=38")
         assert response.status_code == 422
         assert response.json()
@@ -200,7 +200,7 @@ def test_people_geo_bad_param(client):
         assert mock_get.called is False
 
     # non-float param
-    with mock.patch("api.people.requests.get") as mock_get:
+    with mock.patch("api.people.session.get") as mock_get:
         response = client.get("/people.geo?lat=38&lng=abc")
         assert response.status_code == 422
         assert response.json()
@@ -210,7 +210,7 @@ def test_people_geo_bad_param(client):
 
 def test_people_geo_bad_upstream(client):
     # unexpected response from upstream
-    with mock.patch("api.people.requests.get") as mock_get:
+    with mock.patch("api.people.session.get") as mock_get:
         mock_get.return_value.json.return_value = {"endpoint disabled": True}
         response = client.get("/people.geo?lat=50&lng=50")
         assert response.status_code == 500
@@ -220,7 +220,7 @@ def test_people_geo_bad_upstream(client):
 
 
 def test_people_geo_empty(client):
-    with mock.patch("api.people.requests.get") as mock_get:
+    with mock.patch("api.people.session.get") as mock_get:
         mock_get.return_value.json.return_value = {"divisions": []}
         response = client.get("/people.geo?lat=0&lng=0")
         assert response.json() == {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,17 @@ services:
       - "6379:6379"
     networks:
       - openstates-network
+  db-test:
+    image: postgres
+    environment:
+      POSTGRES_USER: 'v3test'
+      POSTGRES_PASSWORD: 'v3test'
+      POSTGRES_DB: 'v3test'
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -q -d v3test -U v3test"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+    ports:
+      - 5432:5432


### PR DESCRIPTION
Two small changes:

1. Create a `requests.Session()` object globally so we can avoid re-negotiating TLS with the geo endpoint on every request.
2. Move the actual request to the geo endpoint into a try block so when the geo endpoint goes down, we handle it more gracefully.

Interestingly, we may have used the stacktraces as a way to monitor the health of the geo endpoint in the past? Given we actually track errors at the load balancer in front of the geo endpoint now, I don't think we need to rely on this any more. But it _is_ worth considering.