### PR TITLE
fix initial build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM antonapetrov/uvicorn-gunicorn-fastapi:python3.9-slim
+FROM bmltenabled/uvicorn-gunicorn-fastapi:python3.9-slim
 
 # improve logging performance (don't buffer messages to output)
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
`antonapetrov/uvicorn-gunicorn-fastapi` has been removed from docker hosting or put behind a paywall of some sort. Moving to a container version that's still available.
