### PR TITLE
Fix pydantic error when note missing on link in jsonb

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -128,7 +128,7 @@ class AltName(BaseModel):
 
 class Link(BaseModel):
     url: str = Field(..., example="https://example.com/")
-    note: str = Field(..., example="homepage")
+    note: Union[str, None] = Field(None, example="homepage")
 
     class Config:
         orm_mode = True
@@ -414,7 +414,7 @@ class EventLocation(BaseModel):
 class EventMedia(BaseModel):
     note: str
     date: str
-    offset: int
+    offset: Union[int, None]
     classification: str
     links: list[Link]
 


### PR DESCRIPTION
We have a lot of data that does not have a note for each link. Also many EventMedia rows are missing offset.

Currently requests for VA events are returning 500 due to this error:

```
10 validation errors for Event
agenda -> 0 -> media -> 0 -> offset
  none is not an allowed value (type=type_error.none.not_allowed)
agenda -> 0 -> media -> 0 -> links -> 0 -> note
  field required (type=value_error.missing)
agenda -> 0 -> media -> 1 -> offset
  none is not an allowed value (type=type_error.none.not_allowed)
agenda -> 0 -> media -> 1 -> links -> 0 -> note
  field required (type=value_error.missing)
agenda -> 0 -> media -> 2 -> offset
  none is not an allowed value (type=type_error.none.not_allowed)
agenda -> 0 -> media -> 2 -> links -> 0 -> note
  field required (type=value_error.missing)
agenda -> 0 -> media -> 3 -> offset
  none is not an allowed value (type=type_error.none.not_allowed)
agenda -> 0 -> media -> 3 -> links -> 0 -> note
  field required (type=value_error.missing)
agenda -> 0 -> media -> 4 -> offset
  none is not an allowed value (type=type_error.none.not_allowed)
agenda -> 0 -> media -> 4 -> links -> 0 -> note
  field required (type=value_error.missing)
```