### PR TITLE
Add order by event ID to sure consistency

### DIFF
--- a/api/events.py
+++ b/api/events.py
@@ -74,7 +74,7 @@ async def event_list(
         .filter(
             jurisdiction_filter(jurisdiction, jid_field=models.Event.jurisdiction_id),
         )
-        .order_by(models.Event.start_date)
+        .order_by(models.Event.start_date, models.Event.id)
     ).options(
         contains_eager(
             models.Event.jurisdiction,


### PR DESCRIPTION
Order by `event.start_date` and `event.id` to ensure position of items are consistent in response.