### PR TITLE
Stop using deprecated datetime.utcnow()

### DIFF
--- a/api/rate_limiter.py
+++ b/api/rate_limiter.py
@@ -60,7 +60,7 @@ class V3RateLimiter:
             timestamp = self.redis.time()[0]
             now = datetime.datetime.fromtimestamp(timestamp)
         else:
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
 
         # check AND increment usage counters
         pipe = self.redis.pipeline()

--- a/api/tests/fixtures.py
+++ b/api/tests/fixtures.py
@@ -66,8 +66,8 @@ def create_test_bill(
         subject=subjects or [],
         classification=classification or ["bill"],
         extras={},
-        created_at=datetime.datetime.utcnow(),
-        updated_at=datetime.datetime.utcnow(),
+        created_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
+        updated_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
         latest_action_date=f"{session.identifier}-02-{random.randint(10,30)}",
         first_action_date=f"{session.identifier}-01-{random.randint(10,30)}",
     )
@@ -330,8 +330,8 @@ def nebraska():
                 "division_id": "ocd-division/country:us/state:ne/sldu:1",
             },
             jurisdiction_id=j.id,
-            created_at=datetime.datetime.utcnow(),
-            updated_at=datetime.datetime.utcnow(),
+            created_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
+            updated_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
         ),
         PersonName(
             person_id=dummy_person_id("1"), name="Amy 'Aardvark' Adams", note="nickname"
@@ -357,8 +357,8 @@ def nebraska():
             party="Libertarian",
             current_role={"org_classification": "executive", "title": "Governor"},
             jurisdiction_id=j.id,
-            created_at=datetime.datetime.utcnow(),
-            updated_at=datetime.datetime.utcnow(),
+            created_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
+            updated_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
         ),
         Person(
             id=dummy_person_id("3"),
@@ -366,8 +366,8 @@ def nebraska():
             birth_date="1973-12-25",
             party="Republican",
             jurisdiction_id=j.id,
-            created_at=datetime.datetime.utcnow(),
-            updated_at=datetime.datetime.utcnow(),
+            created_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
+            updated_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
         ),
     ]
 
@@ -434,8 +434,8 @@ def ohio():
         subject=[],
         classification=["bill"],
         extras={},
-        created_at=datetime.datetime.utcnow(),
-        updated_at=datetime.datetime.utcnow(),
+        created_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
+        updated_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
         latest_action_date="2021-01-01",
     )
     # sb1 = Bill(


### PR DESCRIPTION
Python 3.12 deprecated `datetime.utcnow()`. Swap the rate-limiter and the fixture helpers for `datetime.now(timezone.utc).replace(tzinfo=None)` so the on-the-wire shape stays naive and compares cleanly against the existing `DateTimeField` values.